### PR TITLE
Add support for partial paths

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,16 +1,26 @@
-"use strict"
+'use strict'
 
-const Path = require("path")
-const { _load, Module } = require("module")
+const Path = require('path')
+const { _load, Module } = require('module')
+
+function resolvePath (aliases, src) {
+  let key, path
+  for (key in aliases) {
+    path = aliases[key]
+    if (src.indexOf(key) === 0) {
+      return src.replace(key, path)
+    }
+  }
+  return null
+}
 
 exports.before = config => {
-  const root = Path.resolve(".")
+  const root = Path.resolve('.')
+  const aliases = config.alias || {}
   Module._load = (path, ...rest) => {
-    const alias = config.alias && config.alias[path]
-    if (alias) {
-      return _load(Path.join(root, alias), ...rest)
-    } else {
-      return _load(path, ...rest)
-    }
+    const src = resolvePath(aliases, path)
+    return src
+      ? _load(Path.join(root, src), ...rest)
+      : _load(path, ...rest)
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@ function resolvePath (src, path) {
   if (fs.existsSync(absPath)) {
     return absPath
   }
-  throw new Error('Unable to resolve module "' +src+ '" via aliased path "' + path + '"')
+  throw new Error('Cannot resolve module "' +src+ '" via aliased path "' + path + '"')
 }
 
 exports.before = config => {

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const Path = require('path')
 const { _load, _findPath, Module } = require('module')
 
-function resolvePath (aliases, src) {
+function resolveAlias (aliases, src) {
   let key, path
   for (key in aliases) {
     path = aliases[key]
@@ -15,21 +15,22 @@ function resolvePath (aliases, src) {
   return null
 }
 
-exports.before = config => {
+function resolvePath (src, path) {
   const root = Path.resolve('.')
+  const relPath = Path.join(root, src)
+  const absPath = _findPath(relPath)
+  if (fs.existsSync(absPath)) {
+    return absPath
+  }
+  throw new Error('Unable to resolve module "' +src+ '" via aliased path "' + path + '"')
+}
+
+exports.before = config => {
   const aliases = config.alias || {}
   Module._load = (path, ...rest) => {
-    const src = resolvePath(aliases, path)
-    if (src) {
-      const relPath = Path.join(root, src)
-      const absPath = _findPath(relPath)
-      if (fs.existsSync(absPath)) {
-        return _load(relPath, ...rest)
-      }
-      else {
-        throw new Error('Unable to resolve module "' +src+ '" via aliased path "' + path + '"')
-      }
-    }
-    return _load(path, ...rest)
+    const src = resolveAlias(aliases, path)
+    return src
+      ? _load(resolvePath(src, path), ...rest)
+      : _load(path, ...rest)
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,14 +5,14 @@ const Path = require('path')
 const { _load, _findPath, Module } = require('module')
 
 function resolveAlias (aliases, src) {
-  let key, path
-  for (key in aliases) {
-    path = aliases[key]
-    if (src.indexOf(key) === 0) {
-      return src.replace(key, path)
-    }
-  }
-  return null
+  const key = Object
+    .keys(aliases)
+    .sort()
+    .reverse()
+    .find(key => src.indexOf(key) === 0)
+  return key
+    ? src.replace(key, aliases[key])
+    : undefined
 }
 
 function resolvePath (src, path) {


### PR DESCRIPTION
I've been trying to get local file loading, and thought this plugin would save the day.

However, it looks like it is only possible to alias absolute paths, which effectively makes it useless.

This PR adds support for aliasing partial paths.

See discussions at:

- https://github.com/Gozala/alias-quokka-plugin/issues/4
- https://github.com/wallabyjs/quokka/issues/257

